### PR TITLE
type states,  private API error handling, method naming consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+src/main.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ description = "Compress images while preserving exif data. Provides multi-thread
 categories = ["multimedia::images"]
 repository = "https://github.com/rfdzan/jippigy"
 keywords = ["turbojpeg", "jpeg", "compress", "image", "multimedia"]
+readme = "README.md"
+exclude = ["src/main.rs"]
 
 [dependencies]
 anyhow = "1.0.80"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_quality(95)
     .with_prefix("my_prefix_".to_string())
     .build()
-    .do_single()?;
+    .compress()?;
     Ok(())
 }
 ```
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_prefix("my_prefix_".to_string())
     .with_device(4) // Use 4 threads for this job.
     .build()
-    .do_bulk()?;
+    .compress()?;
     Ok(())
 }
 ```

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,4 +1,4 @@
-use crate::{Compress, HasImageDir, HasOutputDir, DEVICE, QUALITY};
+use crate::{create_output_dir, Compress, HasImageDir, HasOutputDir, DEVICE, QUALITY};
 use crossbeam::deque::Worker;
 use crossbeam::deque::{Steal, Stealer};
 use std::fs::DirEntry;
@@ -44,7 +44,7 @@ where
         self,
         output_dir: T,
     ) -> io::Result<ParallelBuilder<HasImageDir, HasOutputDir, T>> {
-        self.create_output_dir(&output_dir)?;
+        create_output_dir(&output_dir)?;
         Ok(ParallelBuilder {
             image_dir: self.image_dir,
             quality: self.quality,
@@ -88,13 +88,6 @@ where
             prefix: self.prefix,
             _marker: PhantomData,
         }
-    }
-    /// Creates output directory. Exits if it fails.
-    fn create_output_dir(&self, output_dir: &T) -> io::Result<()> {
-        if !output_dir.as_ref().exists() {
-            std::fs::create_dir(output_dir.as_ref())?
-        }
-        Ok(())
     }
 }
 impl<T> ParallelBuilder<HasImageDir, HasOutputDir, T>

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -129,7 +129,7 @@ impl Parallel {
         }
     }
     /// Compress images in parallel.
-    pub fn do_bulk(mut self) -> io::Result<()> {
+    pub fn compress(mut self) -> io::Result<()> {
         let main_worker = Worker::new_fifo();
         for _ in 0..self.device_num {
             self.stealers.push(main_worker.stealer());

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -121,9 +121,9 @@ impl Parallel {
     pub fn builder<T: AsRef<Path> + Default>(image_dir: T) -> ParallelBuilder<HasImageDir, T, T> {
         ParallelBuilder {
             image_dir,
-            quality: 50,
+            quality: QUALITY,
             output_dir: Default::default(),
-            device_num: 4,
+            device_num: DEVICE,
             prefix: Default::default(),
             _marker: PhantomData,
         }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -115,7 +115,7 @@ impl PreserveExif {
     }
     /// Pretty formatting for compressed image size.
     fn format_size_after(&self) -> colored::ColoredString {
-        let in_mbytes = (self.compressed_bytes.len()) as f64 / 1_000_000.0;
+        let in_mbytes = (self.with_exif_preserved.len()) as f64 / 1_000_000.0;
         let as_string = format!("{:.2} MB", in_mbytes);
         as_string.green()
     }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -47,14 +47,6 @@ impl<T: AsRef<Path>> Compress<T> {
     where
         T: AsRef<Path>,
     {
-        // TODO: make this output directory check into a bug check.
-        if !self.output_dir.as_ref().exists() {
-            eprintln!(
-                "Output directory doesn't exist: {}",
-                self.output_dir.as_ref().display()
-            );
-            std::process::exit(1);
-        }
         let path_as_ref = self.path.clone();
         let filename = path_as_ref
             .file_name()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //! # RgbImage::new(1000, 1000).save(image_path.as_path()).unwrap();
 //! # let output_dir = temp_dir.into_path();
 //! Single::builder(image_path)
-//!     .output_dir(output_dir) // This method is required.
+//!     .output_dir(output_dir)? // This method is required.
 //!     .with_quality(95)
 //!     .with_prefix("my_prefix_".to_string())
 //!     .build()
@@ -68,8 +68,19 @@ mod defaults;
 pub mod single;
 /// Type states of structs.
 mod states;
+use std::path::Path;
+
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
 pub(crate) use self::states::{HasImage, HasImageDir, HasOutputDir};
 
-
+/// Attempt to create an output directory.
+pub(crate) fn create_output_dir(output_dir: &impl AsRef<Path>) -> std::io::Result<()> {
+    std::fs::create_dir(output_dir.as_ref()).or_else(|err| {
+        if err.kind() == std::io::ErrorKind::AlreadyExists {
+            Ok(())
+        } else {
+            Err(err)
+        }
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@
 //!     .with_quality(95)
 //!     .with_prefix("my_prefix_".to_string())
 //!     .build()
-//!     .do_single()?;
+//!     .compress()?;
 //! # Ok(())
 //! # }
 //!```
@@ -51,7 +51,7 @@
 //!     .with_prefix("my_prefix_".to_string())
 //!     .with_device(4) // Use 4 threads for this job.
 //!     .build()
-//!     .do_bulk()?;
+//!     .compress()?;
 //! # Ok(())
 //! # }
 //!```

--- a/src/single.rs
+++ b/src/single.rs
@@ -85,8 +85,8 @@ impl Single {
         }
     }
     /// Compress a single image.
-    pub fn do_single(self) -> io::Result<()> {
-        self.exists().compress();
+    pub fn compress(self) -> io::Result<()> {
+        self.exists().do_single();
         Ok(())
     }
     /// Check whether or not image exists.
@@ -108,7 +108,7 @@ impl Single {
         self
     }
     /// Compress a single image.
-    fn compress(self) {
+    fn do_single(self) {
         let prefix = {
             if self.default_prefix.is_empty() {
                 None

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,4 +1,4 @@
-use crate::{Compress, HasImage, HasOutputDir, QUALITY};
+use crate::{create_output_dir, Compress, HasImage, HasOutputDir, QUALITY};
 use colored::Colorize;
 use std::{
     io,
@@ -19,14 +19,15 @@ where
     T: AsRef<Path> + Default,
 {
     /// Output directory of image.
-    pub fn output_dir(self, output_dir: T) -> SingleBuilder<IM, HasOutputDir, T> {
-        SingleBuilder {
+    pub fn output_dir(self, output_dir: T) -> io::Result<SingleBuilder<IM, HasOutputDir, T>> {
+        create_output_dir(&output_dir)?;
+        Ok(SingleBuilder {
             image: self.image,
             quality: self.quality,
             output_dir,
             prefix: self.prefix,
             _marker: PhantomData,
-        }
+        })
     }
     /// Specifies the quality of compressed images.
     /// Defaults to 95 (95% original quality).

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -38,6 +38,7 @@ fn test_single() {
     let prefix = "jippigy_".to_string();
     let single = Single::builder(dummy.image_path_val())
         .output_dir(dummy.temp_dir_val())
+        .unwrap()
         .with_quality(80)
         .with_prefix(prefix.clone())
         .build()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -42,7 +42,7 @@ fn test_single() {
         .with_quality(80)
         .with_prefix(prefix.clone())
         .build()
-        .do_single();
+        .compress();
     assert!(single.is_ok());
     assert!(check_prefix_and_existence(dummy, prefix, false, None));
 }
@@ -63,7 +63,7 @@ fn test_parallel() {
             .with_prefix(prefix.clone())
             .with_device(4) // Use 4 threads for this job.
             .build()
-            .do_bulk();
+            .compress();
         assert!(with_additional_parameters.is_ok());
         assert!(check_prefix_and_existence(
             dummy,


### PR DESCRIPTION
- `output_dir()` in `SingleBuilder` now will fail if specified output directory doesn't exist.
- added type states for `CompressImage`,  simplifying and clearing up the order of operations of its methods a bit. `preserve_exif()` must be invoked first before being able to hand over compressed bytes with exif data to be written out, otherwise `get_compressed_bytes()` will return an error. Hopefully these changes will lead to less human errors in development.
- `do_bulk()` and `do_single()` is now simply `compress()`.