### PR TITLE
1.0.0: Limit crate's responsibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,12 +209,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "gif"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,7 +266,6 @@ dependencies = [
  "crossbeam",
  "image",
  "img-parts",
- "tempdir",
  "turbojpeg",
 ]
 
@@ -388,34 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,24 +398,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -492,16 +439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "turbojpeg"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9af71fa2654444c8dcb711ecbb8f9202778f8421badf71c3d5a118f1570391ed"
+checksum = "aead9835f4441ce185ec2588943b7b566a2f0fa3bd32e7b9d51de103df229d08"
 dependencies = [
  "image",
  "libc",
@@ -567,28 +504,6 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "Compress JPEG while preserving exif data. Provides multi-threaded method for compressing in bulk."
 categories = ["multimedia::images"]
 repository = "https://github.com/rfdzan/jippigy"
-keywords = ["turbojpeg", "jpeg", "compress", "image", "multimedia"]
+keywords = ["turbojpeg", "jpeg", "compress", "image", "exif"]
 readme = "README.md"
 exclude = ["src/main.rs"]
 
@@ -16,5 +16,4 @@ colored = "2.1.0"
 crossbeam = { version = "0.8.4", features = ["crossbeam-deque"] }
 image = "0.24.9"
 img-parts = "0.3.0"
-tempdir = "0.3.7"
 turbojpeg = {version = "1.0", features = ["image"]}

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -202,6 +202,7 @@ impl IntoIterator for Parallel {
         ParallelIntoIterator::new(receiver, handles)
     }
 }
+
 pub struct ParallelIntoIterator {
     recv: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
 }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -2,7 +2,6 @@ use crate::{create_output_dir, Compress, HasImageDir, HasOutputDir, DEVICE, QUAL
 use crossbeam::channel;
 use crossbeam::deque::Worker;
 use crossbeam::deque::{Steal, Stealer};
-use std::fs::DirEntry;
 use std::io;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
@@ -13,6 +12,7 @@ use std::time;
 #[derive(Debug, Clone)]
 pub struct ParallelBuilder<IM, O, T> {
     vec: Vec<Vec<u8>>,
+    image_dir: T,
     quality: u8,
     output_dir: T,
     device_num: u8,
@@ -26,6 +26,7 @@ where
     fn default() -> Self {
         Self {
             vec: Default::default(),
+            image_dir: Default::default(),
             quality: QUALITY,
             output_dir: Default::default(),
             device_num: DEVICE,
@@ -49,6 +50,7 @@ where
         create_output_dir(&output_dir)?;
         Ok(ParallelBuilder {
             vec: self.vec,
+            image_dir: self.image_dir,
             quality: self.quality,
             output_dir,
             device_num: self.device_num,
@@ -61,6 +63,7 @@ where
     pub fn with_quality(self, quality: u8) -> ParallelBuilder<HasImageDir, O, T> {
         ParallelBuilder {
             vec: self.vec,
+            image_dir: self.image_dir,
             quality,
             device_num: self.device_num,
             output_dir: self.output_dir,
@@ -71,6 +74,7 @@ where
     /// Specifies a custom file name prefix for compressed images.
     pub fn with_prefix(self, prefix: String) -> ParallelBuilder<IM, O, T> {
         ParallelBuilder {
+            image_dir: self.image_dir,
             vec: self.vec,
             quality: self.quality,
             device_num: self.device_num,
@@ -83,6 +87,7 @@ where
     /// Defaults to 4.
     pub fn with_device(self, device_num: u8) -> ParallelBuilder<HasImageDir, O, T> {
         ParallelBuilder {
+            image_dir: self.image_dir,
             vec: self.vec,
             quality: self.quality,
             output_dir: self.output_dir,
@@ -100,14 +105,16 @@ where
     pub fn build(self) -> Parallel {
         let (tx, rx) = channel::unbounded();
         Parallel {
-            device_num: self.device_num,
-            quality: self.quality,
             vec: self.vec,
-            output_dir: self.output_dir.as_ref().to_path_buf(),
-            stealers: Vec::with_capacity(usize::from(self.device_num)),
-            prefix: self.prefix,
-            transmitter: tx,
-            receiver: rx,
+            to_thread: StuffThatNeedsToBeSent {
+                device_num: self.device_num,
+                quality: self.quality,
+                output_dir: self.output_dir.as_ref().to_path_buf(),
+                prefix: self.prefix,
+                stealers: Vec::with_capacity(usize::from(self.device_num)),
+                transmitter: tx,
+                receiver: rx,
+            },
         }
     }
 }
@@ -115,7 +122,6 @@ where
 pub struct StuffThatNeedsToBeSent {
     device_num: u8,
     quality: u8,
-    vec: Vec<Vec<u8>>,
     output_dir: PathBuf,
     prefix: String,
     stealers: Vec<Stealer<Vec<u8>>>,
@@ -123,6 +129,7 @@ pub struct StuffThatNeedsToBeSent {
     receiver: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
 }
 impl StuffThatNeedsToBeSent {
+    /// Compress images in parallel.
     fn send_to_threads(
         self,
         tx: channel::Sender<Result<Vec<u8>, anyhow::Error>>,
@@ -197,14 +204,8 @@ impl StuffThatNeedsToBeSent {
 /// Worker threads.
 #[derive(Debug)]
 pub struct Parallel {
-    device_num: u8,
-    quality: u8,
     vec: Vec<Vec<u8>>,
-    output_dir: PathBuf,
-    prefix: String,
-    stealers: Vec<Stealer<Vec<u8>>>,
-    transmitter: channel::Sender<Result<Vec<u8>, anyhow::Error>>,
-    receiver: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
+    to_thread: StuffThatNeedsToBeSent,
 }
 impl Parallel {
     /// Creates a new ParallelBuilder.
@@ -213,6 +214,7 @@ impl Parallel {
     ) -> ParallelBuilder<HasImageDir, T, T> {
         ParallelBuilder {
             vec,
+            image_dir: Default::default(),
             quality: QUALITY,
             output_dir: Default::default(),
             device_num: DEVICE,
@@ -220,97 +222,25 @@ impl Parallel {
             _marker: PhantomData,
         }
     }
-    /// Compress images in parallel.
     fn compress(mut self) -> io::Result<Vec<JoinHandle<()>>> {
         let main_worker = Worker::new_fifo();
         let move_vec = self.vec;
-        for _ in 0..self.device_num {
-            self.stealers.push(main_worker.stealer());
+        for _ in 0..self.to_thread.device_num {
+            self.to_thread.stealers.push(main_worker.stealer());
         }
-        let tx = self.transmitter.clone();
+        let tx = self.to_thread.transmitter.clone();
         for bytes in move_vec {
             main_worker.push(bytes);
         }
-        let handles = self.send_to_threads(tx);
+        let handles = self.to_thread.send_to_threads(tx);
         Ok(handles)
-    }
-    /// Distribute work among threads. /// This method consumes the Parallel and returns a vector containing the handles to each thread.
-    fn send_to_threads(
-        self,
-        tx: channel::Sender<Result<Vec<u8>, anyhow::Error>>,
-    ) -> Vec<thread::JoinHandle<()>> {
-        let mut handles = Vec::with_capacity(usize::from(self.device_num));
-        let to_steal_from = Arc::new(Mutex::new(self.stealers));
-        for _ in 0..self.device_num {
-            let local_stealer = Arc::clone(&to_steal_from);
-            let local_transmitter = tx.clone();
-            let thread_output_dir = self.output_dir.clone();
-            // let thread_custom_name = self.prefix.clone();
-            let thread_custom_name = {
-                if self.prefix.clone().trim().is_empty() {
-                    None
-                } else {
-                    Some(self.prefix.clone())
-                }
-            };
-            let handle = thread::spawn(move || {
-                let mut are_queues_empty = Vec::with_capacity(usize::from(self.device_num));
-                let mut payload = Vec::with_capacity(1);
-                // wait a bit for the main worker to have something in it.
-                thread::sleep(time::Duration::from_millis(1));
-                loop {
-                    {
-                        let Some(stealer_guard) = local_stealer.try_lock().ok() else {
-                            continue;
-                        };
-                        for stealer in stealer_guard.iter() {
-                            let Steal::Success(direntry) = stealer.steal() else {
-                                continue;
-                            };
-                            payload.push(direntry);
-                            break;
-                        }
-                        let _checks = stealer_guard
-                            .iter()
-                            .map(|stealer| {
-                                if stealer.is_empty() {
-                                    are_queues_empty.push(true);
-                                } else {
-                                    are_queues_empty.push(false);
-                                }
-                            })
-                            .collect::<Vec<_>>();
-                        // lock is no longer needed past this point
-                    }
-                    if let Some(bytes) = payload.pop() {
-                        let compress_result = Compress::new(
-                            bytes,
-                            thread_output_dir.clone(),
-                            self.quality,
-                            thread_custom_name.clone(),
-                        )
-                        .compress();
-                        // TODO: return a struct containing original path + compression_result
-                        local_transmitter.send(compress_result).unwrap();
-                    }
-                    // if all stealers are empty, exit the loop.
-                    if are_queues_empty.iter().all(|val| val == &true) {
-                        break;
-                    }
-                    are_queues_empty.clear();
-                    payload.clear();
-                }
-            });
-            handles.push(handle);
-        }
-        handles
     }
 }
 impl IntoIterator for Parallel {
     type Item = Result<Vec<u8>, anyhow::Error>;
     type IntoIter = ParallelIntoIterator;
     fn into_iter(self) -> Self::IntoIter {
-        let receiver = self.receiver.clone();
+        let receiver = self.to_thread.receiver.clone();
         // TODO: this unwrap must be handled
         // not quite sure how to make into_iter() fallible.
         let handles = self.compress();
@@ -334,12 +264,8 @@ impl ParallelIntoIterator {
 impl Iterator for ParallelIntoIterator {
     type Item = Result<Vec<u8>, anyhow::Error>;
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Ok(result) = self.recv.recv() {
-                return Some(result);
-            } else {
-                break;
-            }
+        if let Ok(result) = self.recv.recv() {
+            return Some(result);
         }
         None
     }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,4 +1,5 @@
 use crate::{create_output_dir, Compress, HasImageDir, HasOutputDir, DEVICE, QUALITY};
+use crossbeam::channel;
 use crossbeam::deque::Worker;
 use crossbeam::deque::{Steal, Stealer};
 use std::fs::DirEntry;
@@ -6,9 +7,8 @@ use std::io;
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::thread::{self, JoinHandle};
 use std::time;
-
 /// Custom configuration for building a Parallel.
 #[derive(Debug, Clone)]
 pub struct ParallelBuilder<IM, O, T> {
@@ -96,6 +96,7 @@ where
 {
     /// Builds a new Parallel.
     pub fn build(self) -> Parallel {
+        let (tx, rx) = channel::unbounded();
         Parallel {
             device_num: self.device_num,
             quality: self.quality,
@@ -103,11 +104,13 @@ where
             output_dir: self.output_dir.as_ref().to_path_buf(),
             stealers: Vec::with_capacity(usize::from(self.device_num)),
             prefix: self.prefix,
+            transmitter: tx,
+            receiver: rx,
         }
     }
 }
 /// Worker threads.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Parallel {
     device_num: u8,
     quality: u8,
@@ -115,6 +118,8 @@ pub struct Parallel {
     output_dir: PathBuf,
     prefix: String,
     stealers: Vec<Stealer<Option<DirEntry>>>,
+    transmitter: channel::Sender<Result<Vec<u8>, anyhow::Error>>,
+    receiver: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
 }
 impl Parallel {
     /// Creates a new ParallelBuilder.
@@ -129,28 +134,32 @@ impl Parallel {
         }
     }
     /// Compress images in parallel.
-    pub fn compress(mut self) -> io::Result<()> {
+    fn compress(mut self) -> io::Result<Vec<JoinHandle<()>>> {
         let main_worker = Worker::new_fifo();
         for _ in 0..self.device_num {
             self.stealers.push(main_worker.stealer());
         }
         let read_dir = std::fs::read_dir(self.image_dir.as_path())?;
-        let handles = self.send_to_threads();
+        let tx = self.transmitter.clone();
+        let handles = self.send_to_threads(tx);
         for direntry in read_dir {
             main_worker.push(direntry.ok());
         }
-        for handle in handles.into_iter() {
-            handle.join().unwrap();
-        }
-        Ok(())
+        // for handle in handles.into_iter() {
+        //     handle.join().unwrap();
+        // }
+        Ok(handles)
     }
-    /// Distribute work among threads.
-    /// This method consumes the Parallel and returns a vector containing the handles to each thread.
-    fn send_to_threads(self) -> Vec<thread::JoinHandle<()>> {
+    /// Distribute work among threads. /// This method consumes the Parallel and returns a vector containing the handles to each thread.
+    fn send_to_threads(
+        self,
+        tx: channel::Sender<Result<Vec<u8>, anyhow::Error>>,
+    ) -> Vec<thread::JoinHandle<()>> {
         let mut handles = Vec::with_capacity(usize::from(self.device_num));
         let to_steal_from = Arc::new(Mutex::new(self.stealers));
         for _ in 0..self.device_num {
             let local_stealer = Arc::clone(&to_steal_from);
+            let local_transmitter = tx.clone();
             let thread_output_dir = self.output_dir.clone();
             // let thread_custom_name = self.prefix.clone();
             let thread_custom_name = {
@@ -190,21 +199,15 @@ impl Parallel {
                         // lock is no longer needed past this point
                     }
                     if let Some(Some(path)) = payload.pop() {
-                        match Compress::new(
+                        //TODO: have this result be transmitted to the main thread
+                        let compress_result = Compress::new(
                             path.path(),
                             thread_output_dir.clone(),
                             self.quality,
                             thread_custom_name.clone(),
                         )
-                        .compress()
-                        {
-                            Err(e) => {
-                                eprintln!("{e}");
-                            }
-                            Ok(msg) => {
-                                println!("{msg}");
-                            }
-                        }
+                        .compress();
+                        local_transmitter.send(compress_result).unwrap();
                     }
                     // if all stealers are empty, exit the loop.
                     if are_queues_empty.iter().all(|val| val == &true) {
@@ -217,5 +220,46 @@ impl Parallel {
             handles.push(handle);
         }
         handles
+    }
+}
+impl IntoIterator for Parallel {
+    type Item = Result<Vec<u8>, anyhow::Error>;
+    type IntoIter = ParallelIntoIterator;
+    fn into_iter(self) -> Self::IntoIter {
+        let receiver = self.receiver.clone();
+        // TODO: this unwrap must be handled
+        // not quite sure how to make into_iter() fallible.
+        let handles = self.compress().unwrap();
+        ParallelIntoIterator::new(receiver, handles)
+    }
+}
+pub struct ParallelIntoIterator {
+    handles: Vec<JoinHandle<()>>,
+    recv: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
+}
+impl ParallelIntoIterator {
+    fn new(
+        recv: channel::Receiver<Result<Vec<u8>, anyhow::Error>>,
+        handles: Vec<JoinHandle<()>>,
+    ) -> Self {
+        Self { recv, handles }
+    }
+    // fn compress(mut self) -> io::Result<()> {
+    //     let handles = self.parallel.compress()?;
+    //     self.handles = handles;
+    //     Ok(())
+    // }
+}
+impl Iterator for ParallelIntoIterator {
+    type Item = Result<Vec<u8>, anyhow::Error>;
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Ok(result) = self.recv.recv() {
+                return Some(result);
+            } else {
+                break;
+            }
+        }
+        None
     }
 }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -46,7 +46,7 @@ impl<T: AsRef<Path>> Compress<T> {
     pub(crate) fn compress(&self) -> Result<Vec<u8>, anyhow::Error> {
         // TODO: what about the filename?
         // for now I'm thinking of just straight up ignoring it.
-        let with_exif_preserved = CompressImage::new(self.bytes, self.quality)
+        let with_exif_preserved = CompressImage::new(self.bytes.as_slice(), self.quality)
             .compress()?
             .into_preserve_exif()
             .preserve_exif()?;
@@ -102,17 +102,17 @@ impl PreserveExif {
         as_string.green()
     }
 }
-struct CompressImage {
-    bytes: Vec<u8>,
+struct CompressImage<'a> {
+    bytes: &'a [u8],
     compressed_bytes: Vec<u8>,
     q: u8,
 }
-impl CompressImage {
+impl<'a> CompressImage<'a> {
     /// Creates a new image to be compressed.
-    fn new(bytes: Vec<u8>, q: u8) -> Self {
+    fn new(bytes: &'a [u8], q: u8) -> Self {
         Self {
             q,
-            bytes: Default::default(),
+            bytes,
             compressed_bytes: Default::default(),
         }
     }
@@ -126,7 +126,7 @@ impl CompressImage {
     /// Produce PreserveExif.
     fn into_preserve_exif(self) -> PreserveExif {
         PreserveExif {
-            original_bytes: self.bytes,
+            original_bytes: self.bytes.to_vec(),
             compressed_bytes: self.compressed_bytes,
             with_exif_preserved: Vec::new(),
         }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -24,19 +24,19 @@ impl From<u8> for ValidQuality {
 /// Compression-related work.
 #[derive(Debug, Clone)]
 pub(crate) struct Compress<T: AsRef<Path>> {
-    path: PathBuf,
+    bytes: Vec<u8>,
     output_dir: T,
     quality: u8,
     prefix: Option<String>,
 }
 impl<T: AsRef<Path>> Compress<T> {
     /// Creates a new compression task.
-    pub(crate) fn new(path: PathBuf, output_dir: T, quality: u8, prefix: Option<String>) -> Self
+    pub(crate) fn new(bytes: Vec<u8>, output_dir: T, quality: u8, prefix: Option<String>) -> Self
     where
         T: AsRef<Path>,
     {
         Self {
-            path,
+            bytes,
             output_dir,
             quality: ValidQuality::from(quality).val(),
             prefix,
@@ -44,34 +44,16 @@ impl<T: AsRef<Path>> Compress<T> {
     }
     /// Compresses the image with [turbojpeg](https://github.com/honzasp/rust-turbojpeg) while preserving exif data.
     pub(crate) fn compress(&self) -> Result<Vec<u8>, anyhow::Error> {
-        let filename = self
-            .path
-            .clone()
-            .file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
-            .to_string();
-        let with_exif_preserved = CompressImage::new(self.path.as_path(), self.quality)
+        // TODO: what about the filename?
+        // for now I'm thinking of just straight up ignoring it.
+        let with_exif_preserved = CompressImage::new(self.bytes, self.quality)
             .compress()?
             .into_preserve_exif()
             .preserve_exif()?;
-        // let before_size = with_exif_preserved.format_size_before();
-        // let after_size = with_exif_preserved.format_size_after();
-        // let name = {
-        //     match self.prefix.clone() {
-        //         None => filename,
-        //         Some(n) => n + filename.as_str(),
-        //     }
-        // };
         let to_write = with_exif_preserved.get_compressed_bytes().map_err(|e| {
             eprintln!("{e}");
             e.context(format!("at: {}:{}:{}", file!(), line!(), column!()))
         });
-        // std::fs::write(self.output_dir.as_ref().join(name.as_str()), to_write)?;
-        // let success_msg = format!(
-        //     "{name} before: {before_size} after: {after_size} ({}%)",
-        //     self.quality
-        // );
         to_write
     }
 }
@@ -120,26 +102,23 @@ impl PreserveExif {
         as_string.green()
     }
 }
-struct CompressImage<'a> {
-    p: &'a Path,
-    q: u8,
-    original_bytes: Vec<u8>,
+struct CompressImage {
+    bytes: Vec<u8>,
     compressed_bytes: Vec<u8>,
+    q: u8,
 }
-impl<'a> CompressImage<'a> {
+impl CompressImage {
     /// Creates a new image to be compressed.
-    fn new(p: &'a Path, q: u8) -> Self {
+    fn new(bytes: Vec<u8>, q: u8) -> Self {
         Self {
-            p,
             q,
-            original_bytes: Vec::new(),
-            compressed_bytes: Vec::new(),
+            bytes: Default::default(),
+            compressed_bytes: Default::default(),
         }
     }
     /// Compresses image file, retaining original and compressed bytes. Returns self.
     fn compress(mut self) -> anyhow::Result<Self> {
-        self.original_bytes = std::fs::read(self.p)?;
-        let image: image::RgbImage = decompress_image(self.original_bytes.as_bytes())?;
+        let image: image::RgbImage = decompress_image(self.bytes.as_bytes())?;
         let jpeg_data = compress_image(&image, i32::from(self.q), Sub2x2)?;
         self.compressed_bytes = jpeg_data.as_bytes().to_owned();
         Ok(self)
@@ -147,7 +126,7 @@ impl<'a> CompressImage<'a> {
     /// Produce PreserveExif.
     fn into_preserve_exif(self) -> PreserveExif {
         PreserveExif {
-            original_bytes: self.original_bytes,
+            original_bytes: self.bytes,
             compressed_bytes: self.compressed_bytes,
             with_exif_preserved: Vec::new(),
         }

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -43,7 +43,7 @@ impl<T: AsRef<Path>> Compress<T> {
         }
     }
     /// Compresses the image with [turbojpeg](https://github.com/honzasp/rust-turbojpeg) while preserving exif data.
-    pub(crate) fn compress(&self) -> anyhow::Result<String> {
+    pub(crate) fn compress(&self) -> Result<Vec<u8>, anyhow::Error> {
         let filename = self
             .path
             .clone()
@@ -55,24 +55,24 @@ impl<T: AsRef<Path>> Compress<T> {
             .compress()?
             .into_preserve_exif()
             .preserve_exif()?;
-        let before_size = with_exif_preserved.format_size_before();
-        let after_size = with_exif_preserved.format_size_after();
-        let name = {
-            match self.prefix.clone() {
-                None => filename,
-                Some(n) => n + filename.as_str(),
-            }
-        };
+        // let before_size = with_exif_preserved.format_size_before();
+        // let after_size = with_exif_preserved.format_size_after();
+        // let name = {
+        //     match self.prefix.clone() {
+        //         None => filename,
+        //         Some(n) => n + filename.as_str(),
+        //     }
+        // };
         let to_write = with_exif_preserved.get_compressed_bytes().map_err(|e| {
             eprintln!("{e}");
             e.context(format!("at: {}:{}:{}", file!(), line!(), column!()))
-        })?;
-        std::fs::write(self.output_dir.as_ref().join(name.as_str()), to_write)?;
-        let success_msg = format!(
-            "{name} before: {before_size} after: {after_size} ({}%)",
-            self.quality
-        );
-        Ok(success_msg)
+        });
+        // std::fs::write(self.output_dir.as_ref().join(name.as_str()), to_write)?;
+        // let success_msg = format!(
+        //     "{name} before: {before_size} after: {after_size} ({}%)",
+        //     self.quality
+        // );
+        to_write
     }
 }
 /// Compress an image, retaining its bytes before and after compression.

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,4 +1,4 @@
 /// Quality default.
 pub(crate) const QUALITY: u8 = 95;
 /// Device default.
-pub(crate) const DEVICE: u8 = 4;
+pub(crate) const DEVICE: u8 = 2;

--- a/src/defaults.rs
+++ b/src/defaults.rs
@@ -1,4 +1,4 @@
-/// Quality default.
+/// Default compression ratio.
 pub(crate) const QUALITY: u8 = 95;
-/// Device default.
+/// Default number of threads used.
 pub(crate) const DEVICE: u8 = 2;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,49 +17,47 @@
 
 //! ## Single image compressions with [`Single`]
 //!```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use jippigy::Single;
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use image::{RgbImage, ImageFormat::Jpeg};
 //! # use std::io::Cursor;
-//! # use jippigy::Single;
-//! # let mut vec = Vec::new();
+//!     let mut vec: Vec<u8> = Vec::new();
 //! # let img = RgbImage::new(1000, 1000);
 //! # let _write = img.write_to(&mut Cursor::new(&mut vec), Jpeg).unwrap();
-//! let _result: Vec<u8> = Single::from_bytes(vec.as_slice())
-//!     .with_quality(80)
-//!     .build()
-//!     .compress()?;
-//! # Ok(())
-//! # }
+//!     let _result: Vec<u8> = Single::from_bytes(vec.as_slice())
+//!         .with_quality(80)
+//!         .build()
+//!         .compress()?;
+//!     Ok(())
+//! }
 //!```
 //!
 //! ## Multi-threaded bulk compressions with [`Parallel`]
 //!```
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! use jippigy::Parallel;
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use image::{RgbImage, ImageFormat::Jpeg};
 //! # use std::io::Cursor;
-//! # use jippigy::Parallel;
-//! # let mut list_of_bytes = Vec::new();
+//!     let mut vector_of_bytes: Vec<Vec<u8>> = Vec::new();
 //! # for _ in 0..10 {
 //! #     let mut bytes = Vec::new();
 //! #     let img = RgbImage::new(1000, 1000);
 //! #     let _write = img.write_to(&mut Cursor::new(&mut bytes), Jpeg).unwrap();
-//! #     list_of_bytes.push(bytes);
+//! #     vector_of_bytes.push(bytes);
 //! # }
-//! for result in Parallel::from_vec(list_of_bytes)
-//!     .with_quality(80)
-//!     .with_device(4) // how many threads to use.
-//!     .build()
-//!     .into_iter() {
-//!     let compressed_bytes: Vec<u8> = result?;   
-//!     // do something with the compressed results.
+//!     for result in Parallel::from_vec(vector_of_bytes)
+//!         .with_quality(80)
+//!         .with_device(4) // how many threads to use.
+//!         .build()
+//!         .into_iter() {
+//!         let compressed_bytes: Vec<u8> = result?;   
+//!         // do something with the compressed results.
+//!     }
+//!     Ok(())
 //! }
-//! # Ok(())
-//! # }
 //!```
 //! [`Single`]: single::Single
 //! [`Parallel`]: bulk::Parallel
-//! [`SingleBuilder.output_dir()`]: single::SingleBuilder#output_dir
-//! [`ParallelBuilder.output_dir()`]: bulk::ParallelBuilder#output_dir
 //! [`turbojpeg`]: https://github.com/honzasp/rust-turbojpeg
 //! [`turbojpeg-sys`]: https://github.com/honzasp/rust-turbojpeg/tree/master/turbojpeg-sys
 //! [`Building`]: https://github.com/honzasp/rust-turbojpeg/tree/master/turbojpeg-sys#building
@@ -75,7 +73,10 @@ use std::path::{Path, PathBuf};
 
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
-pub use self::{bulk::Parallel, single::Single};
+pub use self::{
+    bulk::{Parallel, ParallelBuilder},
+    single::{Single, SingleBuilder},
+};
 #[derive(Debug, Clone)]
 pub struct CompressionResult {
     path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //!     let mut vec: Vec<u8> = Vec::new();
 //! # let img = RgbImage::new(1000, 1000);
 //! # let _write = img.write_to(&mut Cursor::new(&mut vec), Jpeg)?;
-//!     let _result: Vec<u8> = Single::from_bytes(vec.as_slice())
+//!     let _result: Vec<u8> = Single::from_bytes(vec)
 //!         .with_quality(80)
 //!         .build()
 //!         .compress()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,17 +68,18 @@
 //! [`turbojpeg-sys`]: https://github.com/honzasp/rust-turbojpeg/tree/master/turbojpeg-sys
 //! [`Building`]: https://github.com/honzasp/rust-turbojpeg/tree/master/turbojpeg-sys#building
 /// Parallelization module.
-pub mod bulk;
+mod bulk;
 /// Compression module.
 mod compress;
 /// Default values.
 mod defaults;
 /// Single-image tasks.
-pub mod single;
+mod single;
 use std::path::{Path, PathBuf};
 
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
+pub use self::{bulk::Parallel, single::Single};
 #[derive(Debug, Clone)]
 pub struct CompressionResult {
     path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,12 +77,28 @@ mod defaults;
 pub mod single;
 /// Type states of structs.
 mod states;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use image::EncodableLayout;
 
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
 pub(crate) use self::states::{HasImage, HasImageDir, HasOutputDir};
-
+pub struct CompressionResult {
+    path: PathBuf,
+    bytes: Vec<u8>,
+}
+impl CompressionResult {
+    pub(crate) fn new(path: PathBuf, bytes: Vec<u8>) -> Self {
+        Self { path, bytes }
+    }
+    pub fn path(&self) -> &Path {
+        self.path.as_path()
+    }
+    pub fn bytes(&self) -> &[u8] {
+        self.bytes.as_bytes()
+    }
+}
 /// Attempt to create an output directory.
 pub(crate) fn create_output_dir(output_dir: &impl AsRef<Path>) -> std::io::Result<()> {
     std::fs::create_dir(output_dir.as_ref()).or_else(|err| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(missing_docs)]
+// #![warn(missing_docs)]
 //! A multi-threaded JPEG compression crate, powered by [turbojpeg](https://github.com/honzasp/rust-turbojpeg).
 //!
 //! This crate provides methods of compressing JPEG images in a single-threaded  or multi-threaded way. Both methods preserves [EXIF](https://en.wikipedia.org/wiki/Exif) data of the original JPEG through [img_parts](https://docs.rs/img-parts/latest/img_parts/) crate.
@@ -75,19 +75,16 @@ mod compress;
 mod defaults;
 /// Single-image tasks.
 pub mod single;
-/// Type states of structs.
-mod states;
 use std::path::{Path, PathBuf};
-
-use image::EncodableLayout;
 
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
-pub(crate) use self::states::{HasImage, HasImageDir, HasOutputDir};
+#[derive(Debug, Clone)]
 pub struct CompressionResult {
     path: PathBuf,
     bytes: Vec<u8>,
 }
+#[allow(dead_code)]
 impl CompressionResult {
     pub(crate) fn new(path: PathBuf, bytes: Vec<u8>) -> Self {
         Self { path, bytes }
@@ -96,16 +93,6 @@ impl CompressionResult {
         self.path.as_path()
     }
     pub fn bytes(&self) -> &[u8] {
-        self.bytes.as_bytes()
+        self.bytes.as_slice()
     }
-}
-/// Attempt to create an output directory.
-pub(crate) fn create_output_dir(output_dir: &impl AsRef<Path>) -> std::io::Result<()> {
-    std::fs::create_dir(output_dir.as_ref()).or_else(|err| {
-        if err.kind() == std::io::ErrorKind::AlreadyExists {
-            Ok(())
-        } else {
-            Err(err)
-        }
-    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@
 //!     Ok(())
 //! }
 //!```
+//!
 //! [`Single`]: single::Single
 //! [`Parallel`]: bulk::Parallel
 //! [`turbojpeg`]: https://github.com/honzasp/rust-turbojpeg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! `with_` methods are optional.
 
 //! ## Single image compressions with [`Single`]
-//!```rust
+//!```ignore
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use image::RgbImage;
 //! # use jippigy::single::Single;
@@ -39,7 +39,7 @@
 //!```
 //!
 //! ## Multi-threaded bulk compressions with [`Parallel`]
-//!```rust
+//!```ignore
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! # use image::RgbImage;
 //! # use jippigy::bulk::Parallel;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 //! A multi-threaded JPEG compression crate, powered by [turbojpeg](https://github.com/honzasp/rust-turbojpeg).
 //!
 //! This crate provides methods of compressing JPEG images in a single-threaded  or multi-threaded way. Both methods preserves [EXIF](https://en.wikipedia.org/wiki/Exif) data of the original JPEG through [img_parts](https://docs.rs/img-parts/latest/img_parts/) crate.
@@ -23,7 +23,7 @@
 //! # use std::io::Cursor;
 //!     let mut vec: Vec<u8> = Vec::new();
 //! # let img = RgbImage::new(1000, 1000);
-//! # let _write = img.write_to(&mut Cursor::new(&mut vec), Jpeg).unwrap();
+//! # let _write = img.write_to(&mut Cursor::new(&mut vec), Jpeg)?;
 //!     let _result: Vec<u8> = Single::from_bytes(vec.as_slice())
 //!         .with_quality(80)
 //!         .build()
@@ -64,13 +64,10 @@
 //! [`Building`]: https://github.com/honzasp/rust-turbojpeg/tree/master/turbojpeg-sys#building
 /// Parallelization module.
 mod bulk;
-/// Compression module.
 mod compress;
-/// Default values.
 mod defaults;
 /// Single-image tasks.
 mod single;
-use std::path::{Path, PathBuf};
 
 pub(crate) use self::compress::Compress;
 pub(crate) use self::defaults::{DEVICE, QUALITY};
@@ -78,20 +75,3 @@ pub use self::{
     bulk::{Parallel, ParallelBuilder},
     single::{Single, SingleBuilder},
 };
-#[derive(Debug, Clone)]
-pub struct CompressionResult {
-    path: PathBuf,
-    bytes: Vec<u8>,
-}
-#[allow(dead_code)]
-impl CompressionResult {
-    pub(crate) fn new(path: PathBuf, bytes: Vec<u8>) -> Self {
-        Self { path, bytes }
-    }
-    pub fn path(&self) -> &Path {
-        self.path.as_path()
-    }
-    pub fn bytes(&self) -> &[u8] {
-        self.bytes.as_slice()
-    }
-}

--- a/src/single.rs
+++ b/src/single.rs
@@ -70,7 +70,7 @@ impl<'a> Single<'a> {
     /// fn main() -> Result<(), Box<dyn std::error::Error>>{
     ///     let mut bytes = Vec::new();
     ///     let img = RgbImage::new(1000, 1000);
-    ///     let _write = img.write_to(&mut Cursor::new(&mut bytes), Jpeg).unwrap();
+    ///     let _write = img.write_to(&mut Cursor::new(&mut bytes), Jpeg)?;
     ///     let _result: Vec<u8> = Single::from_bytes(bytes.as_slice())
     ///         .with_quality(80)
     ///         .build()

--- a/src/single.rs
+++ b/src/single.rs
@@ -65,12 +65,20 @@ impl<'a> Single<'a> {
     /// In order to start the compression, it has to be built first:
     /// ```
     /// use jippigy::Single;     
-    /// fn main() {
-    ///     let bytes: Vec<u8> = Vec::new();   
-    ///     let _single = Single::from_bytes(bytes.as_slice()).build().compress();
+    /// use image::{RgbImage, ImageFormat::Jpeg};
+    /// use std::io::Cursor;
+    /// fn main() -> Result<(), Box<dyn std::error::Error>>{
+    ///     let mut bytes = Vec::new();
+    ///     let img = RgbImage::new(1000, 1000);
+    ///     let _write = img.write_to(&mut Cursor::new(&mut bytes), Jpeg).unwrap();
+    ///     let _result: Vec<u8> = Single::from_bytes(bytes.as_slice())
+    ///         .with_quality(80)
+    ///         .build()
+    ///         .compress()?;
+    ///     Ok(())
     /// }
     /// ```
-    pub fn compress(self) -> anyhow::Result<Vec<u8>> {
-        Compress::new(self.bytes_slice.to_vec(), self.quality).compress()
+    pub fn compress(self) -> Result<Vec<u8>, anyhow::Error> {
+        Ok(Compress::new(self.bytes_slice.to_vec(), self.quality).compress()?)
     }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -8,6 +8,8 @@ pub struct SingleBuilder<'a> {
 impl<'a> SingleBuilder<'a> {
     /// Specifies the quality of compressed images.
     /// Defaults to 95 (95% original quality).
+    ///
+    /// **This method is optional**.
     pub fn with_quality(self, quality: u8) -> SingleBuilder<'a> {
         SingleBuilder {
             bytes_slice: self.bytes_slice,
@@ -17,6 +19,15 @@ impl<'a> SingleBuilder<'a> {
 }
 impl<'a> SingleBuilder<'a> {
     /// Builds a new Single with custom configurations.
+    /// # Example
+    /// This is the minimum requirements for using this method:
+    /// ```
+    /// use jippigy::Single;
+    /// fn main() {
+    ///     let bytes: Vec<u8> = Vec::new();
+    ///     let _build = Single::from_bytes(bytes.as_slice()).build();          
+    /// }
+    /// ```
     pub fn build(self) -> Single<'a> {
         Single {
             bytes_slice: self.bytes_slice,
@@ -31,7 +42,18 @@ pub struct Single<'a> {
     quality: u8,
 }
 impl<'a> Single<'a> {
-    /// Creates a new Single configuration via SingleBuilder.
+    /// Creates a single image compression task from a given byte slice. Returns a [`SingleBuilder`].
+    ///
+    /// This method initializes the compression task with the following defaults:
+    /// - Default final quality is 95% (95% of the original quality).
+    /// # Example
+    /// ```
+    /// use jippigy::Single;     
+    /// fn main() {
+    ///     let bytes: Vec<u8> = Vec::new();   
+    ///     let _single = Single::from_bytes(bytes.as_slice());
+    /// }
+    /// ```
     pub fn from_bytes(bytes_slice: &'a [u8]) -> SingleBuilder {
         SingleBuilder {
             bytes_slice,
@@ -39,6 +61,15 @@ impl<'a> Single<'a> {
         }
     }
     /// Compress a single image.
+    /// # Example
+    /// In order to start the compression, it has to be built first:
+    /// ```
+    /// use jippigy::Single;     
+    /// fn main() {
+    ///     let bytes: Vec<u8> = Vec::new();   
+    ///     let _single = Single::from_bytes(bytes.as_slice()).build().compress();
+    /// }
+    /// ```
     pub fn compress(self) -> anyhow::Result<Vec<u8>> {
         Compress::new(self.bytes_slice.to_vec(), self.quality).compress()
     }

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,23 +1,23 @@
 use crate::{Compress, QUALITY};
 /// Creates a new Single struct for compressing single images.
 #[derive(Debug, Clone)]
-pub struct SingleBuilder<'a> {
-    bytes_slice: &'a [u8],
+pub struct SingleBuilder {
+    bytes_slice: Vec<u8>,
     quality: u8,
 }
-impl<'a> SingleBuilder<'a> {
+impl SingleBuilder {
     /// Specifies the quality of compressed images.
     /// Defaults to 95 (95% original quality).
     ///
     /// **This method is optional**.
-    pub fn with_quality(self, quality: u8) -> SingleBuilder<'a> {
+    pub fn with_quality(self, quality: u8) -> SingleBuilder {
         SingleBuilder {
             bytes_slice: self.bytes_slice,
             quality,
         }
     }
 }
-impl<'a> SingleBuilder<'a> {
+impl SingleBuilder {
     /// Builds a new Single with custom configurations.
     /// # Example
     /// This is the minimum requirements for using this method:
@@ -25,10 +25,10 @@ impl<'a> SingleBuilder<'a> {
     /// use jippigy::Single;
     /// fn main() {
     ///     let bytes: Vec<u8> = Vec::new();
-    ///     let _build = Single::from_bytes(bytes.as_slice()).build();          
+    ///     let _build = Single::from_bytes(bytes).build();          
     /// }
     /// ```
-    pub fn build(self) -> Single<'a> {
+    pub fn build(self) -> Single {
         Single {
             bytes_slice: self.bytes_slice,
             quality: self.quality,
@@ -37,11 +37,11 @@ impl<'a> SingleBuilder<'a> {
 }
 /// Single image compressions.
 #[derive(Debug, Clone)]
-pub struct Single<'a> {
-    bytes_slice: &'a [u8],
+pub struct Single {
+    bytes_slice: Vec<u8>,
     quality: u8,
 }
-impl<'a> Single<'a> {
+impl Single {
     /// Creates a single image compression task from a given byte slice. Returns a [`SingleBuilder`].
     ///
     /// This method initializes the compression task with the following defaults:
@@ -51,10 +51,10 @@ impl<'a> Single<'a> {
     /// use jippigy::Single;     
     /// fn main() {
     ///     let bytes: Vec<u8> = Vec::new();   
-    ///     let _single = Single::from_bytes(bytes.as_slice());
+    ///     let _single = Single::from_bytes(bytes);
     /// }
     /// ```
-    pub fn from_bytes(bytes_slice: &'a [u8]) -> SingleBuilder {
+    pub fn from_bytes(bytes_slice: Vec<u8>) -> SingleBuilder {
         SingleBuilder {
             bytes_slice,
             quality: QUALITY,
@@ -71,7 +71,7 @@ impl<'a> Single<'a> {
     ///     let mut bytes = Vec::new();
     ///     let img = RgbImage::new(1000, 1000);
     ///     let _write = img.write_to(&mut Cursor::new(&mut bytes), Jpeg)?;
-    ///     let _result: Vec<u8> = Single::from_bytes(bytes.as_slice())
+    ///     let _result: Vec<u8> = Single::from_bytes(bytes)
     ///         .with_quality(80)
     ///         .build()
     ///         .compress()?;
@@ -79,6 +79,6 @@ impl<'a> Single<'a> {
     /// }
     /// ```
     pub fn compress(self) -> Result<Vec<u8>, anyhow::Error> {
-        Ok(Compress::new(self.bytes_slice.to_vec(), self.quality).compress()?)
+        Ok(Compress::new(self.bytes_slice, self.quality).compress()?)
     }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,108 +1,45 @@
-use crate::{create_output_dir, Compress, HasImage, HasOutputDir, QUALITY};
-use colored::Colorize;
-use std::{
-    io,
-    marker::PhantomData,
-    path::{Path, PathBuf},
-};
+use crate::{Compress, QUALITY};
 /// Creates a new Single struct for compressing single images.
 #[derive(Debug, Clone)]
-pub struct SingleBuilder<'a, IM, O, T> {
-    bytes: &'a [u8],
+pub struct SingleBuilder<'a> {
+    bytes_slice: &'a [u8],
     quality: u8,
-    output_dir: T,
-    prefix: String,
-    _marker: PhantomData<fn() -> (IM, O)>,
 }
-impl<'a, IM, O, T> SingleBuilder<'a, IM, O, T>
-where
-    T: AsRef<Path> + Default,
-{
-    /// Output directory of image.
-    /// This method is required.
-    pub fn output_dir(self, output_dir: T) -> io::Result<SingleBuilder<'a, IM, HasOutputDir, T>> {
-        create_output_dir(&output_dir)?;
-        Ok(SingleBuilder {
-            bytes: self.bytes,
-            quality: self.quality,
-            output_dir,
-            prefix: self.prefix,
-            _marker: PhantomData,
-        })
-    }
+impl<'a> SingleBuilder<'a> {
     /// Specifies the quality of compressed images.
     /// Defaults to 95 (95% original quality).
-    pub fn with_quality(self, quality: u8) -> SingleBuilder<'a, IM, O, T> {
+    pub fn with_quality(self, quality: u8) -> SingleBuilder<'a> {
         SingleBuilder {
-            bytes: self.bytes,
+            bytes_slice: self.bytes_slice,
             quality,
-            output_dir: self.output_dir,
-            prefix: self.prefix,
-            _marker: PhantomData,
-        }
-    }
-    /// Specifies a custom file name prefix for compressed images.
-    pub fn with_prefix(self, prefix: String) -> SingleBuilder<'a, IM, O, T> {
-        SingleBuilder {
-            bytes: self.bytes,
-            quality: self.quality,
-            output_dir: self.output_dir,
-            prefix,
-            _marker: PhantomData,
         }
     }
 }
-impl<'a, T> SingleBuilder<'a, HasImage, HasOutputDir, T>
-where
-    T: AsRef<Path>,
-{
+impl<'a> SingleBuilder<'a> {
     /// Builds a new Single with custom configurations.
     pub fn build(self) -> Single<'a> {
         Single {
-            bytes: self.bytes,
+            bytes_slice: self.bytes_slice,
             quality: self.quality,
-            output_dir: self.output_dir.as_ref().to_path_buf(),
-            default_prefix: self.prefix,
         }
     }
 }
 /// Single image compressions.
 #[derive(Debug, Clone)]
 pub struct Single<'a> {
-    bytes: &'a [u8],
+    bytes_slice: &'a [u8],
     quality: u8,
-    output_dir: PathBuf,
-    default_prefix: String,
 }
 impl<'a> Single<'a> {
     /// Creates a new Single configuration via SingleBuilder.
-    pub fn from_bytes<T: AsRef<Path> + Default>(bytes: &'a [u8]) -> SingleBuilder<HasImage, T, T> {
+    pub fn from_bytes(bytes_slice: &'a [u8]) -> SingleBuilder {
         SingleBuilder {
-            bytes,
+            bytes_slice,
             quality: QUALITY,
-            output_dir: Default::default(),
-            prefix: Default::default(),
-            _marker: PhantomData,
         }
     }
     /// Compress a single image.
     pub fn compress(self) -> anyhow::Result<Vec<u8>> {
-        self.do_single()
-    }
-    // /// Check whether or not image exists.
-    // fn exists(self) -> io::Result<Self> {
-    //     std::fs::File::open(self.image.as_path())?;
-    //     Ok(self)
-    // }
-    /// Compress a single image.
-    fn do_single(self) -> anyhow::Result<Vec<u8>> {
-        let prefix = {
-            if self.default_prefix.is_empty() {
-                None
-            } else {
-                Some(self.default_prefix)
-            }
-        };
-        Compress::new(self.bytes.to_vec(), self.output_dir, self.quality, prefix).compress()
+        Compress::new(self.bytes_slice.to_vec(), self.quality).compress()
     }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -86,30 +86,16 @@ impl Single {
         }
     }
     /// Compress a single image.
-    pub fn compress(self) -> io::Result<()> {
-        self.exists().do_single();
-        Ok(())
+    pub fn compress(self) -> anyhow::Result<Vec<u8>> {
+        self.exists()?.do_single()
     }
     /// Check whether or not image exists.
-    fn exists(self) -> Self {
-        if !self.image.exists() {
-            eprintln!(
-                "File does not exist: {}. Maybe there's a {}?\nInclude the extension {} as well.",
-                self.image
-                    .file_name()
-                    .unwrap_or_default()
-                    .to_string_lossy()
-                    .to_string()
-                    .red(),
-                "typo".to_string().yellow(),
-                ".jpg/.JPG/.jpeg/.JPEG".to_string().green()
-            );
-            std::process::exit(1);
-        }
-        self
+    fn exists(self) -> io::Result<Self> {
+        std::fs::File::open(self.image.as_path())?;
+        Ok(self)
     }
     /// Compress a single image.
-    fn do_single(self) {
+    fn do_single(self) -> anyhow::Result<Vec<u8>> {
         let prefix = {
             if self.default_prefix.is_empty() {
                 None
@@ -117,9 +103,6 @@ impl Single {
                 Some(self.default_prefix)
             }
         };
-        match Compress::new(self.image, self.output_dir, self.quality, prefix).compress() {
-            Err(e) => eprintln!("{e}"),
-            Ok(msg) => println!("{msg}"),
-        }
+        Compress::new(self.image, self.output_dir, self.quality, prefix).compress()
     }
 }

--- a/src/states.rs
+++ b/src/states.rs
@@ -1,6 +1,0 @@
-/// Current state has image directory.
-pub enum HasImageDir {}
-/// Current state has output directory.
-pub enum HasOutputDir {}
-/// Current state has image path.
-pub enum HasImage {}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -26,11 +26,9 @@ impl Dummy {
     fn image_path_val(&self) -> PathBuf {
         self.image_path.clone()
     }
-    fn create_example_image(&self) {
+    fn create_example_image(&self) -> Vec<u8> {
         fs::File::create(self.image_path.as_path()).unwrap();
-        RgbImage::new(1000, 1000)
-            .save(self.image_path.as_path())
-            .unwrap();
+        RgbImage::new(1000, 1000).into_vec().into()
     }
 }
 fn create_dummy_file() -> Dummy {
@@ -42,7 +40,7 @@ fn test_single() {
     let dummy = create_dummy_file();
     let _create_image = dummy.create_example_image();
     let prefix = PREFIX.to_string();
-    let single = Single::builder(dummy.image_path_val())
+    let single = Single::from_bytes(dummy.create_example_image().as_slice())
         .output_dir(dummy.temp_dir_val())
         .unwrap()
         .with_quality(80)
@@ -50,7 +48,7 @@ fn test_single() {
         .build()
         .compress();
     assert!(single.is_ok());
-    assert!(check_prefix_and_existence(dummy, prefix, false, None));
+    // assert!(check_prefix_and_existence(dummy, prefix, false, None));
 }
 // #[test]
 // fn test_parallel() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -17,13 +17,13 @@ impl Dummy {
 #[test]
 fn test_basic_failing_single() {
     let failing = Dummy::create_failing_image();
-    let single = Single::from_bytes(failing.as_slice()).build().compress();
+    let single = Single::from_bytes(failing).build().compress();
     assert!(single.is_err());
 }
 #[test]
 fn test_basic_success_single() {
     let success = Dummy::create_jpeg_image();
-    let single = Single::from_bytes(success.as_slice()).build().compress();
+    let single = Single::from_bytes(success).build().compress();
     assert!(single.is_ok());
 }
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,11 @@
 use image::{ImageFormat::Jpeg, RgbImage};
-use jippigy::{bulk::Parallel, single::Single};
+use jippigy::{Parallel, Single};
 use std::io::Cursor;
 
 struct Dummy {}
 impl Dummy {
     fn create_failing_image() -> Vec<u8> {
-        RgbImage::new(1000, 1000).into_vec().into()
+        RgbImage::new(1000, 1000).into_vec()
     }
     fn create_jpeg_image() -> Vec<u8> {
         let mut jpeg = Vec::new();
@@ -15,21 +15,21 @@ impl Dummy {
     }
 }
 #[test]
-fn test_failing_single() {
+fn test_basic_failing_single() {
     let failing = Dummy::create_failing_image();
     let single = Single::from_bytes(failing.as_slice()).build().compress();
     assert!(single.is_err());
 }
 #[test]
-fn test_success_single() {
+fn test_basic_success_single() {
     let success = Dummy::create_jpeg_image();
     let single = Single::from_bytes(success.as_slice()).build().compress();
     assert!(single.is_ok());
 }
 #[test]
-fn test_failing_parallel() {
+fn test_basic_failing_parallel() {
     let mut failing = Vec::new();
-    for _ in 0..20 {
+    for _ in 0..10 {
         failing.push(Dummy::create_failing_image());
     }
     for res in Parallel::from_vec(failing).build().into_iter() {
@@ -37,9 +37,9 @@ fn test_failing_parallel() {
     }
 }
 #[test]
-fn test_success_parallel() {
+fn test_basic_success_parallel() {
     let mut success = Vec::new();
-    for _ in 0..20 {
+    for _ in 0..10 {
         success.push(Dummy::create_jpeg_image());
     }
     for res in Parallel::from_vec(success).build().into_iter() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::path::PathBuf;
 
 const EXAMPLE_JPEG_NAME: &str = "example_jpeg.jpg";
-const PREFIX: &str = "jippigy_";
 const TEMP_DIR_NAME: &str = "example";
 const RESULT_DIR_NAME: &str = "compressed";
 
@@ -39,12 +38,8 @@ fn create_dummy_file() -> Dummy {
 fn test_single() {
     let dummy = create_dummy_file();
     let _create_image = dummy.create_example_image();
-    let prefix = PREFIX.to_string();
     let single = Single::from_bytes(dummy.create_example_image().as_slice())
-        .output_dir(dummy.temp_dir_val())
-        .unwrap()
         .with_quality(80)
-        .with_prefix(prefix.clone())
         .build()
         .compress();
     assert!(single.is_ok());
@@ -76,24 +71,24 @@ fn test_single() {
 //         ));
 //     }
 // }
-fn check_prefix_and_existence(
-    dummy: Dummy,
-    expected: String,
-    parallel: bool,
-    dir: Option<&str>,
-) -> bool {
-    if !parallel {
-        let file = dummy
-            .temp_dir_val()
-            .join(expected.to_string() + EXAMPLE_JPEG_NAME);
-        println!("{}", file.display());
-        file.exists()
-    } else {
-        let file = dummy
-            .temp_dir_val()
-            .join(dir.unwrap_or_default())
-            .join(expected.to_string() + EXAMPLE_JPEG_NAME);
-        println!("{}", file.display());
-        file.exists()
-    }
-}
+// fn check_prefix_and_existence(
+//     dummy: Dummy,
+//     expected: String,
+//     parallel: bool,
+//     dir: Option<&str>,
+// ) -> bool {
+//     if !parallel {
+//         let file = dummy
+//             .temp_dir_val()
+//             .join(expected.to_string() + EXAMPLE_JPEG_NAME);
+//         println!("{}", file.display());
+//         file.exists()
+//     } else {
+//         let file = dummy
+//             .temp_dir_val()
+//             .join(dir.unwrap_or_default())
+//             .join(expected.to_string() + EXAMPLE_JPEG_NAME);
+//         println!("{}", file.display());
+//         file.exists()
+//     }
+// }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,94 +1,48 @@
-use image::RgbImage;
+use image::{ImageFormat::Jpeg, RgbImage};
 use jippigy::{bulk::Parallel, single::Single};
-use std::fs;
-use std::path::PathBuf;
+use std::io::Cursor;
 
-const EXAMPLE_JPEG_NAME: &str = "example_jpeg.jpg";
-const TEMP_DIR_NAME: &str = "example";
-const RESULT_DIR_NAME: &str = "compressed";
-
-struct Dummy {
-    temp_dir: tempdir::TempDir,
-    image_path: PathBuf,
-}
+struct Dummy {}
 impl Dummy {
-    fn new(temp_dir: tempdir::TempDir) -> Self {
-        let image_path = temp_dir.path().join(EXAMPLE_JPEG_NAME);
-        Self {
-            temp_dir,
-            image_path,
-        }
-    }
-    fn temp_dir_val(&self) -> PathBuf {
-        self.temp_dir.path().to_path_buf()
-    }
-    fn image_path_val(&self) -> PathBuf {
-        self.image_path.clone()
-    }
-    fn create_example_image(&self) -> Vec<u8> {
-        fs::File::create(self.image_path.as_path()).unwrap();
+    fn create_failing_image() -> Vec<u8> {
         RgbImage::new(1000, 1000).into_vec().into()
     }
-}
-fn create_dummy_file() -> Dummy {
-    let temp_dir = tempdir::TempDir::new(TEMP_DIR_NAME).unwrap();
-    Dummy::new(temp_dir)
+    fn create_jpeg_image() -> Vec<u8> {
+        let mut jpeg = Vec::new();
+        let img = RgbImage::new(1000, 1000);
+        let _write = img.write_to(&mut Cursor::new(&mut jpeg), Jpeg).unwrap();
+        jpeg
+    }
 }
 #[test]
-fn test_single() {
-    let dummy = create_dummy_file();
-    let _create_image = dummy.create_example_image();
-    let single = Single::from_bytes(dummy.create_example_image().as_slice())
-        .with_quality(80)
-        .build()
-        .compress();
-    assert!(single.is_ok());
-    // assert!(check_prefix_and_existence(dummy, prefix, false, None));
+fn test_failing_single() {
+    let failing = Dummy::create_failing_image();
+    let single = Single::from_bytes(failing.as_slice()).build().compress();
+    assert!(single.is_err());
 }
-// #[test]
-// fn test_parallel() {
-//     let dummy = create_dummy_file();
-//     let _create_image = dummy.create_example_image();
-//     let prefix = PREFIX.to_string();
-
-//     let parallel_has_image_dir = Parallel::builder(dummy.temp_dir_val())
-//         .output_dir(dummy.temp_dir_val().join(RESULT_DIR_NAME)); // This method is required.
-//     assert!(parallel_has_image_dir.is_ok());
-
-//     if let Ok(parallel) = parallel_has_image_dir {
-//         let with_additional_parameters = parallel
-//             .with_quality(95)
-//             .with_prefix(prefix.clone())
-//             .with_device(4) // Use 4 threads for this job.
-//             .build()
-//             .compress();
-//         assert!(with_additional_parameters.is_ok());
-//         assert!(check_prefix_and_existence(
-//             dummy,
-//             prefix,
-//             true,
-//             Some(RESULT_DIR_NAME)
-//         ));
-//     }
-// }
-// fn check_prefix_and_existence(
-//     dummy: Dummy,
-//     expected: String,
-//     parallel: bool,
-//     dir: Option<&str>,
-// ) -> bool {
-//     if !parallel {
-//         let file = dummy
-//             .temp_dir_val()
-//             .join(expected.to_string() + EXAMPLE_JPEG_NAME);
-//         println!("{}", file.display());
-//         file.exists()
-//     } else {
-//         let file = dummy
-//             .temp_dir_val()
-//             .join(dir.unwrap_or_default())
-//             .join(expected.to_string() + EXAMPLE_JPEG_NAME);
-//         println!("{}", file.display());
-//         file.exists()
-//     }
-// }
+#[test]
+fn test_success_single() {
+    let success = Dummy::create_jpeg_image();
+    let single = Single::from_bytes(success.as_slice()).build().compress();
+    assert!(single.is_ok());
+}
+#[test]
+fn test_failing_parallel() {
+    let mut failing = Vec::new();
+    for _ in 0..20 {
+        failing.push(Dummy::create_failing_image());
+    }
+    for res in Parallel::from_vec(failing).build().into_iter() {
+        assert!(res.is_err());
+    }
+}
+#[test]
+fn test_success_parallel() {
+    let mut success = Vec::new();
+    for _ in 0..20 {
+        success.push(Dummy::create_jpeg_image());
+    }
+    for res in Parallel::from_vec(success).build().into_iter() {
+        assert!(res.is_ok());
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -52,32 +52,32 @@ fn test_single() {
     assert!(single.is_ok());
     assert!(check_prefix_and_existence(dummy, prefix, false, None));
 }
-#[test]
-fn test_parallel() {
-    let dummy = create_dummy_file();
-    let _create_image = dummy.create_example_image();
-    let prefix = PREFIX.to_string();
+// #[test]
+// fn test_parallel() {
+//     let dummy = create_dummy_file();
+//     let _create_image = dummy.create_example_image();
+//     let prefix = PREFIX.to_string();
 
-    let parallel_has_image_dir = Parallel::builder(dummy.temp_dir_val())
-        .output_dir(dummy.temp_dir_val().join(RESULT_DIR_NAME)); // This method is required.
-    assert!(parallel_has_image_dir.is_ok());
+//     let parallel_has_image_dir = Parallel::builder(dummy.temp_dir_val())
+//         .output_dir(dummy.temp_dir_val().join(RESULT_DIR_NAME)); // This method is required.
+//     assert!(parallel_has_image_dir.is_ok());
 
-    if let Ok(parallel) = parallel_has_image_dir {
-        let with_additional_parameters = parallel
-            .with_quality(95)
-            .with_prefix(prefix.clone())
-            .with_device(4) // Use 4 threads for this job.
-            .build()
-            .compress();
-        assert!(with_additional_parameters.is_ok());
-        assert!(check_prefix_and_existence(
-            dummy,
-            prefix,
-            true,
-            Some(RESULT_DIR_NAME)
-        ));
-    }
-}
+//     if let Ok(parallel) = parallel_has_image_dir {
+//         let with_additional_parameters = parallel
+//             .with_quality(95)
+//             .with_prefix(prefix.clone())
+//             .with_device(4) // Use 4 threads for this job.
+//             .build()
+//             .compress();
+//         assert!(with_additional_parameters.is_ok());
+//         assert!(check_prefix_and_existence(
+//             dummy,
+//             prefix,
+//             true,
+//             Some(RESULT_DIR_NAME)
+//         ));
+//     }
+// }
 fn check_prefix_and_existence(
     dummy: Dummy,
     expected: String,
@@ -85,7 +85,6 @@ fn check_prefix_and_existence(
     dir: Option<&str>,
 ) -> bool {
     if !parallel {
-
         let file = dummy
             .temp_dir_val()
             .join(expected.to_string() + EXAMPLE_JPEG_NAME);


### PR DESCRIPTION
After a discussion that I had about refactoring of some public API in this crate with another developer, they pointed out that some methods are overburdened. I realized they were right. Having to:

1. read a directory
2. read the file
3. compress
4. saving the file

...is doing more than what goal I set this crate for in the first place: *compressing JPEG images*, while preserving the original EXIF data + added multi-threaded capability out of the box if there's a lot of JPEGs.
 
So I decided I'm only going to do  point number 3.

Now the crate will only be responsible for handling image bytes, everything else is handed over to the user of the crate.