### PR TITLE
docs: removed redundant explanation, consistent docs across `builder`…

### DIFF
--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -163,7 +163,7 @@ impl Parallel {
     ///     let _parallel = Parallel::from_vec(vector_of_bytes);
     /// }
     /// ```
-    /// In order to start the compression, it has to be built and made into an iterator with `into_iter`:
+    /// In order to start the compression, it has to be made into an iterator with `into_iter`:
     /// ```
     /// use jippigy::Parallel;
     /// fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/single.rs
+++ b/src/single.rs
@@ -1,6 +1,7 @@
-
 use crate::{error, Compress, QUALITY};
-/// Creates a new Single struct for compressing single images.
+/// Custom configuration for building a [`Single`].
+/// This struct is not meant to be used directly.
+/// Use [`Single::from_bytes`] instead.
 #[derive(Debug, Clone)]
 pub struct SingleBuilder {
     bytes_slice: Vec<u8>,
@@ -63,7 +64,6 @@ impl Single {
     }
     /// Compress a single image.
     /// # Example
-    /// In order to start the compression, it has to be built first:
     /// ```
     /// use jippigy::Single;     
     /// use image::{RgbImage, ImageFormat::Jpeg};


### PR DESCRIPTION
… structs

closes #29 