### PR TITLE
Sync thread output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = ["src/main.rs"]
 
 [dependencies]
-crossbeam = { version = "0.8.4", features = ["crossbeam-deque"] }
+crossbeam = "0.8.4"
 image = "0.24.9"
 img-parts = "0.3.0"
 thiserror = "1.0.58"

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -87,7 +87,6 @@ impl StuffThatNeedsToBeSent {
     ) -> Vec<thread::JoinHandle<()>> {
         let mut handles = Vec::with_capacity(usize::from(self.device_num));
         let counter = Arc::new(Mutex::new(0usize));
-        // let to_steal_from = Arc::new(Mutex::new(self.stealers));
         let to_steal_from = Arc::new(Mutex::new(self.vec));
         for _ in 0..self.device_num {
             let local_stealer = Arc::clone(&to_steal_from);
@@ -97,7 +96,7 @@ impl StuffThatNeedsToBeSent {
                 let mut payload = Vec::with_capacity(1);
                 loop {
                     {
-                        let Some(mut stealer_guard) = local_stealer.try_lock().ok() else {
+                        let Some(mut stealer_guard) = local_stealer.lock().ok() else {
                             continue;
                         };
                         if let Some(bytes) = stealer_guard.pop_front() {
@@ -111,7 +110,7 @@ impl StuffThatNeedsToBeSent {
                         let compress_result = Compress::new(content.1, self.quality).compress();
                         loop {
                             {
-                                let Some(mut counter_guard) = local_counter.try_lock().ok() else {
+                                let Some(mut counter_guard) = local_counter.lock().ok() else {
                                     continue;
                                 };
                                 if !(*counter_guard == content.0) {

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -124,12 +124,12 @@ impl StuffThatNeedsToBeSent {
                                 } else {
                                     *counter_guard = *counter_guard + 1;
                                 }
-                            }
-                            match local_transmitter.send(compress_result) {
-                                Err(e) => {
-                                    eprintln!("{e:#?}");
+                                match local_transmitter.send(compress_result) {
+                                    Err(e) => {
+                                        eprintln!("{e:#?}");
+                                    }
+                                    Ok(_) => {}
                                 }
-                                Ok(_) => {}
                             }
                             break;
                         }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -26,12 +26,10 @@ impl ParallelBuilder {
     pub fn build(self) -> Parallel {
         let (tx, rx) = channel::unbounded();
         Parallel {
-            main_worker: Worker::new_fifo(),
-            vec: self.vec,
             to_thread: StuffThatNeedsToBeSent {
+                vec: self.vec,
                 device_num: self.device_num,
                 quality: self.quality,
-                stealers: Vec::with_capacity(usize::from(self.device_num)),
             },
             transmitter: tx,
             receiver: rx,
@@ -61,30 +59,6 @@ impl ParallelBuilder {
             vec: self.vec,
             quality: self.quality,
             device_num,
-        }
-    }
-}
-impl ParallelBuilder {
-    /// Builds a new [`Parallel`] with default or specified configuration.
-    /// # Example
-    /// This is the minimal requirements for using this method:
-    /// ```
-    /// # fn main() {
-    /// # use jippigy::Parallel;
-    /// let mut vector_of_bytes: Vec<Vec<u8>> = Vec::new();
-    /// let _build = Parallel::from_vec(vector_of_bytes).build();
-    /// # }
-    /// ```
-    pub fn build(self) -> Parallel {
-        let (tx, rx) = channel::unbounded();
-        Parallel {
-            to_thread: StuffThatNeedsToBeSent {
-                vec: self.vec,
-                device_num: self.device_num,
-                quality: self.quality,
-            },
-            transmitter: tx,
-            receiver: rx,
         }
     }
 }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -105,26 +105,11 @@ impl StuffThatNeedsToBeSent {
                         let Some(mut stealer_guard) = local_stealer.try_lock().ok() else {
                             continue;
                         };
-                        // for stealer in stealer_guard.iter() {
-                        //     let Steal::Success(direntry) = stealer.steal() else {
-                        //         continue;
-                        //     };
                         if let Some(bytes) = stealer_guard.pop_front() {
                             payload.push(bytes);
                         } else {
                             break;
                         }
-                        // let _checks = stealer_guard
-                        //     .iter()
-                        //     .map(|stealer| {
-                        //         if stealer.is_empty() {
-                        //             are_queues_empty.push(true);
-                        //         } else {
-                        //             are_queues_empty.push(false);
-                        //         }
-                        //     })
-                        //     .collect::<Vec<_>>();
-
                         // lock is no longer needed past this point
                     }
                     if let Some(content) = payload.pop() {
@@ -132,13 +117,9 @@ impl StuffThatNeedsToBeSent {
                         loop {
                             {
                                 let Some(mut counter_guard) = local_counter.try_lock().ok() else {
-                                    // println!("contending for lock");
                                     continue;
                                 };
                                 if !(*counter_guard == content.0) {
-                                    // println!("{}", content.0);
-                                    // println!("stuck in this check");
-                                    // drop(counter_guard);
                                     continue;
                                 } else {
                                     *counter_guard = *counter_guard + 1;
@@ -150,15 +131,9 @@ impl StuffThatNeedsToBeSent {
                                 }
                                 Ok(_) => {}
                             }
-                            // println!("here");
                             break;
                         }
                     }
-                    // if all stealers are empty, exit the loop.
-                    // if are_queues_empty.iter().all(|val| val == &true) {
-                    //     break;
-                    // }
-                    // are_queues_empty.clear();
                     payload.clear();
                 }
             });


### PR DESCRIPTION
- **Multithreaded compressions now output bytes in the same order they go in**. Allowing for users to push the names of files into another vector and `zip` the result.
- Removed `crossbeam_deque` feature as this crate doesn't need it anymore.
- `Mutex` locks now blocks to avoid busy waits.

This PR is not perfect performance wise, but the main goal of syncing the output is achieved.